### PR TITLE
use v1 version of ClusterRoleBinding

### DIFF
--- a/catalog/task/func-deploy/0.1/support/knative-deployer.yaml
+++ b/catalog/task/func-deploy/0.1/support/knative-deployer.yaml
@@ -25,7 +25,7 @@ rules:
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-deployer-binding


### PR DESCRIPTION

use v1 version of ClusterRoleBinding, v1beta1 is not supported on newer k8s versions